### PR TITLE
Release version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is inspired by Keep a Changelog and follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-01
+
+### Added
+- Sungrow iSolarCloud API transform specification with OAuth 2.0 authentication support.
+- Sungrow Python transformer implementation (`SungrowTransformer`) supporting plant_realtime, device_telemetry, and historical_data endpoints.
+- Device status code mapping (16 codes) and plant status code mapping (6 codes) to ODS-E error types.
+- 3-phase AC electrical parameter handling with voltage averaging and current summing.
+- Multi-string DC parameter support with max voltage and summed current calculations.
+- Power factor calculation from active/apparent power when not directly available.
+- Comprehensive API documentation including rate limits, OAuth flow, and timezone handling.
+- Support for complete ODS-E electrical parameters: kW, kWh, kVA, kVAr, PF, voltage_ac, current_ac, frequency, voltage_dc, current_dc, temperature.
+
 ## [0.5.0] - 2026-03-15
 
 ### Added

--- a/src/python/odse/__init__.py
+++ b/src/python/odse/__init__.py
@@ -5,7 +5,7 @@ A Python library for validating and transforming energy asset data
 using the ODS-E specification.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 from .validator import (
     validate,

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odse"
-version = "0.5.0"
+version = "0.6.0"
 description = "Open Data Schema for Energy - validation and transformation library"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
- Update CHANGELOG.md with Sungrow iSolarCloud API additions
- Bump version to 0.6.0 in __init__.py and pyproject.toml
- Add comprehensive release notes for Sungrow transformer and specification

## Summary

- What changed:
- Why:

## Change Class

- [ ] routine
- [ ] normative
- [ ] breaking
- [ ] security

## Validation

- [ ] `PYTHONPATH=src/python python3 -m unittest discover -s src/python/tests -v`
- [ ] `PYTHONPATH=src/python python3 tools/transform_harness.py --mode fixture`

## Compatibility

- [ ] No breaking behavior
- [ ] Breaking behavior (migration notes included)
- [ ] Deprecation notice included (if applicable)

## Documentation

- [ ] README/docs updated
- [ ] Changelog updated (if release-facing)
