### PR TITLE
Add wind turbine SCADA transforms for Vestas, Siemens Gamesa, and Nordex (SEP-025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is inspired by Keep a Changelog and follows semantic versioning.
 ## [Unreleased]
 
 ### Added
+- Wind turbine SCADA transforms (SEP-025): `VestasTransformer` (Vestas Online), `SiemensGamesaTransformer` (Siemens Gamesa Diagnostic System), and `NordexTransformer` (Nordex Control), registered under source keys `vestas`, `siemens_gamesa`, and `nordex`.
+- Four optional wind schema fields in `energy-timeseries.json`: `wind_speed_ms`, `rotor_rpm`, `blade_pitch_deg`, and `nacelle_direction_deg` (0–360).
+- `wind_scada` conformance profile requiring `wind_speed_ms`.
+- Transform specifications `transforms/vestas-online.yaml`, `transforms/siemens-gamesa-diagnostic.yaml`, and `transforms/nordex-control.yaml`.
+- SEP-025 spec document `spec/wind-transforms.md`.
 - BESS transforms (SEP-026): `SungrowBESSTransformer` (Sungrow PowerTitan via iSolarCloud) and `BYDBESSTransformer` (BYD BatteryBox / BMS CSV export), registered under source keys `sungrow_bess` and `byd_bess`.
 - Eight optional BESS schema fields in `energy-timeseries.json`: `charge_kWh`, `discharge_kWh`, `cycle_count`, `cell_temp_min_c`, `cell_temp_max_c`, `cell_voltage_min_v`, `cell_voltage_max_v`, and `dispatch_mode` (enum: charging/discharging/standby/balancing).
 - `bess_dispatch` conformance profile requiring `dispatch_mode` and `soc`.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -120,6 +120,7 @@ SEP numbers are assigned sequentially and never reused. Current allocations:
 - SEP-001: Runtime validator parity for SA trading schema fields.
 - SEP-002: SA trading conformance profiles.
 - SEP-003: Reference enrichment contract.
+- SEP-025: Wind turbine SCADA transforms (Vestas, Siemens Gamesa, Nordex) and wind schema fields.
 - SEP-026: BESS transforms (Sungrow PowerTitan, BYD) and dispatch schema fields.
 
 ## Labels and Workflow

--- a/schemas/energy-timeseries.json
+++ b/schemas/energy-timeseries.json
@@ -303,6 +303,26 @@
       "type": "string",
       "enum": ["charging", "discharging", "standby", "balancing"],
       "description": "Battery dispatch state for this interval."
+    },
+    "wind_speed_ms": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Wind speed in meters per second."
+    },
+    "rotor_rpm": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Rotor revolutions per minute."
+    },
+    "blade_pitch_deg": {
+      "type": "number",
+      "description": "Blade pitch angle in degrees."
+    },
+    "nacelle_direction_deg": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 360,
+      "description": "Nacelle orientation in degrees (0-360, compass bearing)."
     }
   },
   "if": {

--- a/spec/wind-transforms.md
+++ b/spec/wind-transforms.md
@@ -1,0 +1,174 @@
+# Wind Turbine SCADA Transforms (SEP-025)
+
+Status: Draft
+Last updated: 2026-06-27
+
+## Purpose
+
+Wind turbines produce fundamentally different telemetry from solar inverters or battery storage: wind speed, rotor RPM, blade pitch angles, and nacelle orientation. ODS-E had 10 solar inverter transforms and 2 BESS transforms but zero wind turbine transforms. This SEP adds wind-specific schema fields and three transformer classes for the dominant wind turbine OEMs in the African IPP market.
+
+This SEP defines:
+
+1. Four new optional schema fields for wind turbine telemetry.
+2. Three transformer classes (Vestas, Siemens Gamesa, Nordex).
+3. A `wind_scada` conformance profile for wind record validation.
+
+## Context
+
+Globeleq manages 1,794 MW of generation capacity including significant wind across multiple African countries. The three dominant wind turbine OEMs in the African IPP market are Vestas, Siemens Gamesa, and Nordex. Their SCADA systems export different tag naming conventions, status codes, and data structures. Adding wind transforms extends ODS-E from a solar-and-storage tool to a full renewable energy data standard.
+
+## Scope
+
+**Affected surfaces:** runtime, transforms, schemas.
+
+**Decision class:** Normative (adds optional schema fields; no existing fields changed). Requires 2 maintainer approvals + 7-day public comment window per [GOVERNANCE.md](../GOVERNANCE.md).
+
+## New Schema Fields
+
+All fields are optional and additive. Existing records remain valid.
+
+| Field | Type | Constraint | Description |
+|-------|------|-----------|-------------|
+| `wind_speed_ms` | number | min 0 | Wind speed in meters per second. |
+| `rotor_rpm` | number | min 0 | Rotor revolutions per minute. |
+| `blade_pitch_deg` | number | — | Blade pitch angle in degrees. |
+| `nacelle_direction_deg` | number | 0–360 | Nacelle orientation in degrees (compass bearing). |
+
+These fields capture the fundamental wind telemetry that has no equivalent in solar or BESS schemas. Wind speed is the primary driver of production; rotor RPM and blade pitch indicate turbine operating state; nacelle direction enables yaw alignment analysis.
+
+## Transformers
+
+### Vestas (`vestas`)
+
+- **Source key:** `vestas` (aliases: `vestas-online`)
+- **Class:** `VestasTransformer`
+- **Input:** Vestas Online Business SCADA CSV export
+- **Transform spec:** [`transforms/vestas-online.yaml`](../transforms/vestas-online.yaml)
+
+Maps Vestas SCADA CSV columns to ODS-E fields:
+
+| Vestas column | ODS-E field |
+|---------------|-------------|
+| `active_power_kw` | `kW`, `kWh` (via power × interval) |
+| `wind_speed` | `wind_speed_ms` |
+| `rotor_rpm` | `rotor_rpm` |
+| `nacelle_position` | `nacelle_direction_deg` |
+| `blade_pitch` | `blade_pitch_deg` |
+| `generator_temp` | `temperature` |
+| `grid_frequency` | `frequency` |
+| `turbine_state` (0–5) | `error_type` (via state mapping) |
+
+Turbine state mapping:
+
+| Code | State | ODS-E error_type |
+|------|-------|-----------------|
+| 0 | Offline | `offline` |
+| 1 | Standby | `standby` |
+| 2 | Normal | `normal` |
+| 3 | Warning | `warning` |
+| 4 | Fault | `fault` |
+| 5 | Maintenance | `warning` |
+
+The default `interval_minutes` is 10, matching the standard Vestas SCADA 10-minute reporting interval.
+
+### Siemens Gamesa (`siemens_gamesa`)
+
+- **Source key:** `siemens_gamesa` (aliases: `siemens-gamesa`, `sgre`)
+- **Class:** `SiemensGamesaTransformer`
+- **Input:** Siemens Gamesa Diagnostic System SCADA CSV export
+- **Transform spec:** [`transforms/siemens-gamesa-diagnostic.yaml`](../transforms/siemens-gamesa-diagnostic.yaml)
+
+Maps Siemens Gamesa SCADA CSV columns to ODS-E fields:
+
+| SGRE column | ODS-E field |
+|-------------|-------------|
+| `active_power_kw` | `kW`, `kWh` (via power × interval) |
+| `reactive_power_kvar` | `kVAr` |
+| `wind_speed_nacelle` | `wind_speed_ms` (fallback: `wind_speed_metmast`) |
+| `rotor_speed` | `rotor_rpm` |
+| `pitch_angle` | `blade_pitch_deg` |
+| `bearing_temp` | `temperature` |
+| `availability_status` | `error_type` (via status mapping) |
+
+Availability status mapping:
+
+| Status | ODS-E error_type |
+|--------|-----------------|
+| `full` | `normal` |
+| `limited` | `warning` |
+| `standstill` | `standby` |
+| `error` | `fault` |
+| `offline` | `offline` |
+| `maintenance` | `warning` |
+
+Wind speed is measured at two locations: the nacelle-mounted anemometer (`wind_speed_nacelle`) and the met mast (`wind_speed_metmast`). The transformer prefers the nacelle reading and falls back to the met mast when the nacelle value is absent.
+
+### Nordex (`nordex`)
+
+- **Source key:** `nordex` (aliases: `nordex-control`)
+- **Class:** `NordexTransformer`
+- **Input:** Nordex Control SCADA CSV export
+- **Transform spec:** [`transforms/nordex-control.yaml`](../transforms/nordex-control.yaml)
+
+Maps Nordex SCADA CSV columns to ODS-E fields:
+
+| Nordex column | ODS-E field |
+|---------------|-------------|
+| `active_power_kw` | `kW`, `kWh` (via power × interval) |
+| `wind_speed` | `wind_speed_ms` |
+| `rotor_speed` | `rotor_rpm` |
+| `blade_angle` | `blade_pitch_deg` |
+| `generator_temp` | `temperature` |
+| `turbine_status` | `error_type` (via status mapping) |
+
+Turbine status mapping:
+
+| Status | ODS-E error_type |
+|--------|-----------------|
+| `running` | `normal` |
+| `standby` | `standby` |
+| `paused` | `standby` |
+| `warning` | `warning` |
+| `error` | `fault` |
+| `offline` | `offline` |
+| `maintenance` | `warning` |
+
+The `paused` state is mapped to `standby` as it represents an intentional temporary stop (e.g., waiting for wind), distinct from a manual `standby` hold.
+
+## Conformance Profile: `wind_scada`
+
+A validator-level conformance profile layered on top of the schema. Does not change the schema itself.
+
+### Required Fields
+
+| Field | Value Constraint |
+|-------|-----------------|
+| `wind_speed_ms` | — |
+
+### Usage
+
+```python
+from odse import validate
+
+result = validate(record, profile="wind_scada")
+```
+
+Profile validation runs after schema validation passes. Error codes follow the existing profile convention (`UNKNOWN_PROFILE`, `PROFILE_FIELD_MISSING`, `PROFILE_VALUE_MISMATCH`).
+
+## Compatibility Impact
+
+**Normative — additive only.** All new fields are optional. No existing fields are changed, removed, or renamed. Existing records (solar, BESS, meter, regulatory) remain valid without modification. The `wind_scada` profile is opt-in and does not affect default validation.
+
+## Out of Scope
+
+- Live SCADA API clients (only CSV/JSON export transforms).
+- Turbine-specific analytics (power curves, wake modeling).
+- Met mast data transforms (met mast wind speed is used only as a fallback for nacelle wind speed).
+- Curtailed energy estimation for wind (existing `curtailed_kWh` field applies).
+
+## Related Docs
+
+- [Conformance Profiles](conformance-profiles.md) — profile validation framework (SEP-002)
+- [BESS Transforms](bess-transforms.md) — BESS schema fields and transformers (SEP-026)
+- [Schema: energy-timeseries](../schemas/energy-timeseries.json)
+- [Governance](../GOVERNANCE.md) — SEP lifecycle and approval thresholds

--- a/src/python/odse/transformer.py
+++ b/src/python/odse/transformer.py
@@ -96,6 +96,13 @@ def _get_transformer(source: str):
         "byd_bess": BYDBESSTransformer(),
         "byd-bess": BYDBESSTransformer(),
         "byd": BYDBESSTransformer(),
+        "vestas": VestasTransformer(),
+        "vestas-online": VestasTransformer(),
+        "siemens_gamesa": SiemensGamesaTransformer(),
+        "siemens-gamesa": SiemensGamesaTransformer(),
+        "sgre": SiemensGamesaTransformer(),
+        "nordex": NordexTransformer(),
+        "nordex-control": NordexTransformer(),
         "csv": GenericCSVTransformer(),
         "generic_csv": GenericCSVTransformer(),
         "generic": GenericCSVTransformer(),
@@ -1625,6 +1632,254 @@ class BYDBESSTransformer(BaseTransformer):
                 rec["kW"] = -charge_kw
             elif discharge_kw is not None:
                 rec["kW"] = discharge_kw
+
+            records.append(rec)
+
+        return records
+
+
+class VestasTransformer(BaseTransformer):
+    """Transform Vestas Online SCADA CSV export to ODS-E.
+
+    Expected CSV columns: timestamp, active_power_kw, wind_speed,
+    rotor_rpm, nacelle_position, yaw_error, blade_pitch,
+    generator_temp, grid_frequency, turbine_state.
+    """
+
+    # turbine_state (integer) -> error_type
+    TURBINE_STATE_MAPPING = {
+        0: "offline",
+        1: "standby",
+        2: "normal",
+        3: "warning",
+        4: "fault",
+        5: "warning",  # maintenance
+    }
+
+    def transform(self, data: Union[str, Path], **kwargs) -> List[Dict[str, Any]]:
+        rows = self._parse_csv_rows(data)
+        timezone = kwargs.get("timezone")
+        interval_hours = (kwargs.get("interval_minutes", 10) or 10) / 60.0
+        asset_id = kwargs.get("asset_id")
+
+        records: List[Dict[str, Any]] = []
+        for row in rows:
+            ts_raw = _first_value(row, ["timestamp", "Timestamp", "Time", "datetime"])
+            iso_ts = _to_iso8601(ts_raw, timezone=timezone)
+            if not iso_ts:
+                continue
+
+            power_kw = _to_float(
+                _first_value(row, ["active_power_kw", "active_power", "power_kw", "Power"])
+            )
+            kwh = max((power_kw or 0.0) * interval_hours, 0.0)
+
+            turbine_state = _to_int(
+                _first_value(row, ["turbine_state", "state", "status", "Status"])
+            )
+            error_type = self.TURBINE_STATE_MAPPING.get(
+                turbine_state if turbine_state is not None else -1, "unknown",
+            )
+
+            rec = _base_record(
+                timestamp=iso_ts,
+                kwh=kwh,
+                error_type=error_type,
+                error_code=turbine_state,
+                asset_id=asset_id,
+            )
+
+            if power_kw is not None:
+                rec["kW"] = power_kw
+
+            wind_speed = _to_float(_first_value(row, ["wind_speed", "WindSpeed", "wind_speed_ms"]))
+            if wind_speed is not None:
+                rec["wind_speed_ms"] = max(0.0, wind_speed)
+
+            rotor_rpm = _to_float(_first_value(row, ["rotor_rpm", "rotor_speed", "RotorRPM"]))
+            if rotor_rpm is not None:
+                rec["rotor_rpm"] = max(0.0, rotor_rpm)
+
+            nacelle_pos = _to_float(
+                _first_value(row, ["nacelle_position", "nacelle_direction", "NacellePosition"])
+            )
+            if nacelle_pos is not None:
+                rec["nacelle_direction_deg"] = max(0.0, min(360.0, nacelle_pos))
+
+            blade_pitch = _to_float(_first_value(row, ["blade_pitch", "pitch_angle", "BladePitch"]))
+            if blade_pitch is not None:
+                rec["blade_pitch_deg"] = blade_pitch
+
+            gen_temp = _to_float(_first_value(row, ["generator_temp", "GeneratorTemp"]))
+            if gen_temp is not None:
+                rec["temperature"] = gen_temp
+
+            grid_freq = _to_float(_first_value(row, ["grid_frequency", "frequency", "GridFreq"]))
+            if grid_freq is not None:
+                rec["frequency"] = grid_freq
+
+            records.append(rec)
+
+        return records
+
+
+class SiemensGamesaTransformer(BaseTransformer):
+    """Transform Siemens Gamesa Diagnostic System SCADA CSV export to ODS-E.
+
+    Expected CSV columns: timestamp, active_power_kw, reactive_power_kvar,
+    wind_speed_nacelle, wind_speed_metmast, rotor_speed, pitch_angle,
+    generator_speed, bearing_temp, availability_status.
+    """
+
+    # availability_status (string) -> error_type
+    AVAILABILITY_MAPPING = {
+        "full": "normal",
+        "limited": "warning",
+        "standstill": "standby",
+        "error": "fault",
+        "offline": "offline",
+        "maintenance": "warning",
+    }
+
+    def transform(self, data: Union[str, Path], **kwargs) -> List[Dict[str, Any]]:
+        rows = self._parse_csv_rows(data)
+        timezone = kwargs.get("timezone")
+        interval_hours = (kwargs.get("interval_minutes", 10) or 10) / 60.0
+        asset_id = kwargs.get("asset_id")
+
+        records: List[Dict[str, Any]] = []
+        for row in rows:
+            ts_raw = _first_value(row, ["timestamp", "Timestamp", "Time", "datetime"])
+            iso_ts = _to_iso8601(ts_raw, timezone=timezone)
+            if not iso_ts:
+                continue
+
+            power_kw = _to_float(
+                _first_value(row, ["active_power_kw", "active_power", "power_kw", "Power"])
+            )
+            kwh = max((power_kw or 0.0) * interval_hours, 0.0)
+
+            status_raw = _first_value(
+                row, ["availability_status", "status", "Status", "availability"]
+            )
+            error_type = "unknown"
+            if status_raw is not None:
+                status_key = str(status_raw).strip().lower()
+                error_type = self.AVAILABILITY_MAPPING.get(status_key, "unknown")
+
+            rec = _base_record(
+                timestamp=iso_ts,
+                kwh=kwh,
+                error_type=error_type,
+                error_code=status_raw,
+                asset_id=asset_id,
+            )
+
+            if power_kw is not None:
+                rec["kW"] = power_kw
+
+            reactive_kvar = _to_float(
+                _first_value(row, ["reactive_power_kvar", "reactive_power", "ReactivePower"])
+            )
+            if reactive_kvar is not None:
+                rec["kVAr"] = reactive_kvar
+
+            wind_speed = _to_float(
+                _first_value(row, ["wind_speed_nacelle", "wind_speed", "WindSpeed"])
+            )
+            if wind_speed is None:
+                wind_speed = _to_float(
+                    _first_value(row, ["wind_speed_metmast", "metmast_wind_speed"])
+                )
+            if wind_speed is not None:
+                rec["wind_speed_ms"] = max(0.0, wind_speed)
+
+            rotor_speed = _to_float(_first_value(row, ["rotor_speed", "rotor_rpm", "RotorSpeed"]))
+            if rotor_speed is not None:
+                rec["rotor_rpm"] = max(0.0, rotor_speed)
+
+            pitch_angle = _to_float(_first_value(row, ["pitch_angle", "blade_pitch", "PitchAngle"]))
+            if pitch_angle is not None:
+                rec["blade_pitch_deg"] = pitch_angle
+
+            bearing_temp = _to_float(_first_value(row, ["bearing_temp", "BearingTemp"]))
+            if bearing_temp is not None:
+                rec["temperature"] = bearing_temp
+
+            records.append(rec)
+
+        return records
+
+
+class NordexTransformer(BaseTransformer):
+    """Transform Nordex Control SCADA CSV export to ODS-E.
+
+    Expected CSV columns: timestamp, active_power_kw, wind_speed,
+    rotor_speed, blade_angle, generator_temp, transformer_temp,
+    turbine_status.
+    """
+
+    # turbine_status (string) -> error_type
+    TURBINE_STATUS_MAPPING = {
+        "running": "normal",
+        "standby": "standby",
+        "paused": "standby",
+        "warning": "warning",
+        "error": "fault",
+        "offline": "offline",
+        "maintenance": "warning",
+    }
+
+    def transform(self, data: Union[str, Path], **kwargs) -> List[Dict[str, Any]]:
+        rows = self._parse_csv_rows(data)
+        timezone = kwargs.get("timezone")
+        interval_hours = (kwargs.get("interval_minutes", 10) or 10) / 60.0
+        asset_id = kwargs.get("asset_id")
+
+        records: List[Dict[str, Any]] = []
+        for row in rows:
+            ts_raw = _first_value(row, ["timestamp", "Timestamp", "Time", "datetime"])
+            iso_ts = _to_iso8601(ts_raw, timezone=timezone)
+            if not iso_ts:
+                continue
+
+            power_kw = _to_float(
+                _first_value(row, ["active_power_kw", "active_power", "power_kw", "Power"])
+            )
+            kwh = max((power_kw or 0.0) * interval_hours, 0.0)
+
+            status_raw = _first_value(row, ["turbine_status", "status", "Status", "state"])
+            error_type = "unknown"
+            if status_raw is not None:
+                status_key = str(status_raw).strip().lower()
+                error_type = self.TURBINE_STATUS_MAPPING.get(status_key, "unknown")
+
+            rec = _base_record(
+                timestamp=iso_ts,
+                kwh=kwh,
+                error_type=error_type,
+                error_code=status_raw,
+                asset_id=asset_id,
+            )
+
+            if power_kw is not None:
+                rec["kW"] = power_kw
+
+            wind_speed = _to_float(_first_value(row, ["wind_speed", "WindSpeed", "wind_speed_ms"]))
+            if wind_speed is not None:
+                rec["wind_speed_ms"] = max(0.0, wind_speed)
+
+            rotor_speed = _to_float(_first_value(row, ["rotor_speed", "rotor_rpm", "RotorSpeed"]))
+            if rotor_speed is not None:
+                rec["rotor_rpm"] = max(0.0, rotor_speed)
+
+            blade_angle = _to_float(_first_value(row, ["blade_angle", "blade_pitch", "BladeAngle"]))
+            if blade_angle is not None:
+                rec["blade_pitch_deg"] = blade_angle
+
+            gen_temp = _to_float(_first_value(row, ["generator_temp", "GeneratorTemp"]))
+            if gen_temp is not None:
+                rec["temperature"] = gen_temp
 
             records.append(rec)
 

--- a/src/python/odse/validator.py
+++ b/src/python/odse/validator.py
@@ -89,6 +89,10 @@ PROFILES = {
             ],
         },
     },
+    "wind_scada": {
+        "required_fields": ["wind_speed_ms"],
+        "field_constraints": {},
+    },
 }
 
 
@@ -492,6 +496,24 @@ def _validate_schema(data: dict) -> List[ValidationError]:
         data, "dispatch_mode",
         ["charging", "discharging", "standby", "balancing"], errors,
     )
+
+    # --- Wind SCADA (SEP-025) ---
+    _check_optional_type(data, "wind_speed_ms", "number", errors, "number")
+    _check_optional_minimum(data, "wind_speed_ms", 0, errors)
+
+    _check_optional_type(data, "rotor_rpm", "number", errors, "number")
+    _check_optional_minimum(data, "rotor_rpm", 0, errors)
+
+    _check_optional_type(data, "blade_pitch_deg", "number", errors, "number")
+
+    _check_optional_type(data, "nacelle_direction_deg", "number", errors, "number")
+    _check_optional_minimum(data, "nacelle_direction_deg", 0, errors)
+    if "nacelle_direction_deg" in data and isinstance(data["nacelle_direction_deg"], (int, float)) and data["nacelle_direction_deg"] > 360:
+        errors.append(ValidationError(
+            path="$.nacelle_direction_deg",
+            message="nacelle_direction_deg must be <= 360",
+            code="OUT_OF_BOUNDS",
+        ))
 
     return errors
 

--- a/src/python/tests/fixtures/nordex_control_sample.csv
+++ b/src/python/tests/fixtures/nordex_control_sample.csv
@@ -1,0 +1,4 @@
+timestamp,active_power_kw,wind_speed,rotor_speed,blade_angle,generator_temp,transformer_temp,turbine_status
+2026-06-27T10:00:00Z,1500.0,7.8,12.5,5.0,62.0,45.0,running
+2026-06-27T10:10:00Z,0.0,3.0,2.0,80.0,40.0,35.0,paused
+2026-06-27T10:20:00Z,0.0,11.0,0.0,90.0,38.0,34.0,error

--- a/src/python/tests/fixtures/siemens_gamesa_sample.csv
+++ b/src/python/tests/fixtures/siemens_gamesa_sample.csv
@@ -1,0 +1,4 @@
+timestamp,active_power_kw,reactive_power_kvar,wind_speed_nacelle,wind_speed_metmast,rotor_speed,pitch_angle,generator_speed,bearing_temp,availability_status
+2026-06-27T10:00:00Z,2100.0,300.0,8.7,8.5,13.5,3.2,1450.0,58.4,full
+2026-06-27T10:10:00Z,800.0,150.0,5.2,5.0,9.0,12.0,980.0,52.0,limited
+2026-06-27T10:20:00Z,0.0,,,,0.0,90.0,0.0,40.0,offline

--- a/src/python/tests/fixtures/vestas_online_sample.csv
+++ b/src/python/tests/fixtures/vestas_online_sample.csv
@@ -1,0 +1,4 @@
+timestamp,active_power_kw,wind_speed,rotor_rpm,nacelle_position,yaw_error,blade_pitch,generator_temp,grid_frequency,turbine_state
+2026-06-27T10:00:00Z,1800.0,9.5,14.2,270.5,2.1,4.5,65.3,50.02,2
+2026-06-27T10:10:00Z,0.0,2.8,3.1,271.0,1.5,85.0,42.1,49.98,1
+2026-06-27T10:20:00Z,0.0,12.0,0.0,271.0,0.0,90.0,38.0,50.01,4

--- a/src/python/tests/test_wind_transforms.py
+++ b/src/python/tests/test_wind_transforms.py
@@ -1,0 +1,312 @@
+"""Tests for wind turbine SCADA transformers (Vestas, Siemens Gamesa, Nordex) — SEP-025."""
+
+import pytest
+from pathlib import Path
+
+from odse.transformer import (
+    transform,
+    VestasTransformer,
+    SiemensGamesaTransformer,
+    NordexTransformer,
+)
+from odse.validator import validate, PROFILES
+
+
+@pytest.fixture
+def fixtures_dir():
+    return Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Vestas Online
+# ---------------------------------------------------------------------------
+
+def test_vestas_production(fixtures_dir):
+    transformer = VestasTransformer()
+    records = transformer.transform(
+        fixtures_dir / "vestas_online_sample.csv",
+        interval_minutes=10,
+        asset_id="za-globeleq:wind:vestas-001",
+    )
+
+    assert len(records) == 3
+
+    rec0 = records[0]
+    assert rec0["asset_id"] == "za-globeleq:wind:vestas-001"
+    assert rec0["timestamp"] == "2026-06-27T10:00:00+00:00"
+    assert rec0["error_type"] == "normal"
+    assert rec0["wind_speed_ms"] == 9.5
+    assert rec0["rotor_rpm"] == 14.2
+    assert rec0["nacelle_direction_deg"] == 270.5
+    assert rec0["blade_pitch_deg"] == 4.5
+    assert rec0["kW"] == 1800.0
+    # 1800 kW * (10/60) h = 300 kWh
+    assert rec0["kWh"] == pytest.approx(1800.0 * (10.0 / 60.0))
+
+
+def test_vestas_standby(fixtures_dir):
+    transformer = VestasTransformer()
+    records = transformer.transform(
+        fixtures_dir / "vestas_online_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec1 = records[1]
+    assert rec1["error_type"] == "standby"
+    assert rec1["kWh"] == 0.0
+    assert rec1["wind_speed_ms"] == 2.8
+    assert rec1["blade_pitch_deg"] == 85.0
+
+
+def test_vestas_fault(fixtures_dir):
+    transformer = VestasTransformer()
+    records = transformer.transform(
+        fixtures_dir / "vestas_online_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec2 = records[2]
+    assert rec2["error_type"] == "fault"
+    assert rec2["kWh"] == 0.0
+    assert rec2["rotor_rpm"] == 0.0
+
+
+def test_vestas_via_transform_dispatch(fixtures_dir):
+    records = transform(
+        fixtures_dir / "vestas_online_sample.csv",
+        source="vestas",
+        interval_minutes=10,
+    )
+    assert len(records) == 3
+    assert {r["error_type"] for r in records} == {"normal", "standby", "fault"}
+
+
+def test_vestas_empty_payload():
+    transformer = VestasTransformer()
+    records = transformer.transform("timestamp,active_power_kw,wind_speed\n")
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Siemens Gamesa Diagnostic System
+# ---------------------------------------------------------------------------
+
+def test_siemens_gamesa_production(fixtures_dir):
+    transformer = SiemensGamesaTransformer()
+    records = transformer.transform(
+        fixtures_dir / "siemens_gamesa_sample.csv",
+        interval_minutes=10,
+        asset_id="za-globeleq:wind:sgre-001",
+    )
+
+    assert len(records) == 3
+
+    rec0 = records[0]
+    assert rec0["asset_id"] == "za-globeleq:wind:sgre-001"
+    assert rec0["timestamp"] == "2026-06-27T10:00:00+00:00"
+    assert rec0["error_type"] == "normal"
+    assert rec0["wind_speed_ms"] == 8.7
+    assert rec0["rotor_rpm"] == 13.5
+    assert rec0["blade_pitch_deg"] == 3.2
+    assert rec0["kW"] == 2100.0
+    assert rec0["kVAr"] == 300.0
+    assert rec0["kWh"] == pytest.approx(2100.0 * (10.0 / 60.0))
+
+
+def test_siemens_gamesa_warning(fixtures_dir):
+    transformer = SiemensGamesaTransformer()
+    records = transformer.transform(
+        fixtures_dir / "siemens_gamesa_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec1 = records[1]
+    assert rec1["error_type"] == "warning"
+    assert rec1["wind_speed_ms"] == 5.2
+    assert rec1["kW"] == 800.0
+
+
+def test_siemens_gamesa_offline(fixtures_dir):
+    transformer = SiemensGamesaTransformer()
+    records = transformer.transform(
+        fixtures_dir / "siemens_gamesa_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec2 = records[2]
+    assert rec2["error_type"] == "offline"
+    # wind_speed_nacelle and wind_speed_metmast are empty in the fixture
+    assert "wind_speed_ms" not in rec2
+
+
+def test_siemens_gamesa_via_transform_dispatch(fixtures_dir):
+    records = transform(
+        fixtures_dir / "siemens_gamesa_sample.csv",
+        source="siemens_gamesa",
+        interval_minutes=10,
+    )
+    assert len(records) == 3
+
+
+def test_siemens_gamesa_empty_payload():
+    transformer = SiemensGamesaTransformer()
+    records = transformer.transform("timestamp,active_power_kw,availability_status\n")
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Nordex Control
+# ---------------------------------------------------------------------------
+
+def test_nordex_production(fixtures_dir):
+    transformer = NordexTransformer()
+    records = transformer.transform(
+        fixtures_dir / "nordex_control_sample.csv",
+        interval_minutes=10,
+        asset_id="za-globeleq:wind:nordex-001",
+    )
+
+    assert len(records) == 3
+
+    rec0 = records[0]
+    assert rec0["asset_id"] == "za-globeleq:wind:nordex-001"
+    assert rec0["timestamp"] == "2026-06-27T10:00:00+00:00"
+    assert rec0["error_type"] == "normal"
+    assert rec0["wind_speed_ms"] == 7.8
+    assert rec0["rotor_rpm"] == 12.5
+    assert rec0["blade_pitch_deg"] == 5.0
+    assert rec0["kW"] == 1500.0
+    assert rec0["kWh"] == pytest.approx(1500.0 * (10.0 / 60.0))
+
+
+def test_nordex_paused(fixtures_dir):
+    transformer = NordexTransformer()
+    records = transformer.transform(
+        fixtures_dir / "nordex_control_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec1 = records[1]
+    assert rec1["error_type"] == "standby"
+    assert rec1["kWh"] == 0.0
+    assert rec1["wind_speed_ms"] == 3.0
+
+
+def test_nordex_fault(fixtures_dir):
+    transformer = NordexTransformer()
+    records = transformer.transform(
+        fixtures_dir / "nordex_control_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec2 = records[2]
+    assert rec2["error_type"] == "fault"
+    assert rec2["kWh"] == 0.0
+    assert rec2["rotor_rpm"] == 0.0
+
+
+def test_nordex_via_transform_dispatch(fixtures_dir):
+    records = transform(
+        fixtures_dir / "nordex_control_sample.csv",
+        source="nordex",
+        interval_minutes=10,
+    )
+    assert len(records) == 3
+
+
+def test_nordex_empty_payload():
+    transformer = NordexTransformer()
+    records = transformer.transform("timestamp,active_power_kw,turbine_status\n")
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Schema validation of transformer output
+# ---------------------------------------------------------------------------
+
+def test_wind_output_schema_valid(fixtures_dir):
+    for fixture_name, source in [
+        ("vestas_online_sample.csv", "vestas"),
+        ("siemens_gamesa_sample.csv", "siemens_gamesa"),
+        ("nordex_control_sample.csv", "nordex"),
+    ]:
+        records = transform(
+            fixtures_dir / fixture_name,
+            source=source,
+            interval_minutes=10,
+        )
+        for rec in records:
+            result = validate(rec)
+            assert not result.errors, f"{source}: Schema errors: {result.errors}"
+
+
+# ---------------------------------------------------------------------------
+# wind_scada conformance profile
+# ---------------------------------------------------------------------------
+
+def test_wind_scada_profile_registered():
+    assert "wind_scada" in PROFILES
+
+
+def test_wind_scada_profile_valid(fixtures_dir):
+    records = transform(
+        fixtures_dir / "vestas_online_sample.csv",
+        source="vestas",
+        interval_minutes=10,
+    )
+    # First two records have wind_speed_ms; third (fault) also has it
+    for rec in records:
+        result = validate(rec, profile="wind_scada")
+        assert not result.errors, f"Profile errors: {result.errors}"
+
+
+def test_wind_scada_profile_missing_wind_speed():
+    rec = {
+        "timestamp": "2026-06-27T10:00:00Z",
+        "kWh": 300.0,
+        "error_type": "normal",
+        "rotor_rpm": 14.2,
+    }
+    result = validate(rec, profile="wind_scada")
+    codes = [e.code for e in result.errors]
+    assert "PROFILE_FIELD_MISSING" in codes
+
+
+# ---------------------------------------------------------------------------
+# Wind field bounds
+# ---------------------------------------------------------------------------
+
+def test_wind_speed_bounds():
+    rec = {
+        "timestamp": "2026-06-27T10:00:00Z",
+        "kWh": 300.0,
+        "error_type": "normal",
+        "wind_speed_ms": -1.5,
+    }
+    result = validate(rec)
+    codes = [e.code for e in result.errors]
+    assert "OUT_OF_BOUNDS" in codes
+
+
+def test_nacelle_direction_bounds():
+    rec = {
+        "timestamp": "2026-06-27T10:00:00Z",
+        "kWh": 300.0,
+        "error_type": "normal",
+        "nacelle_direction_deg": 370.0,
+    }
+    result = validate(rec)
+    codes = [e.code for e in result.errors]
+    assert "OUT_OF_BOUNDS" in codes
+
+
+def test_rotor_rpm_bounds():
+    rec = {
+        "timestamp": "2026-06-27T10:00:00Z",
+        "kWh": 300.0,
+        "error_type": "normal",
+        "rotor_rpm": -5.0,
+    }
+    result = validate(rec)
+    codes = [e.code for e in result.errors]
+    assert "OUT_OF_BOUNDS" in codes

--- a/tools/transform_harness.py
+++ b/tools/transform_harness.py
@@ -31,6 +31,9 @@ CANONICAL_OEMS = [
     "solis",
     "solaxcloud",
     "higeco",
+    "vestas",
+    "siemens_gamesa",
+    "nordex",
 ]
 
 FIXTURES: Dict[str, str] = {
@@ -125,6 +128,18 @@ FIXTURES: Dict[str, str] = {
             "inverterStatus": "102",
         },
     }),
+    "vestas": (
+        "timestamp,active_power_kw,wind_speed,rotor_rpm,nacelle_position,yaw_error,blade_pitch,generator_temp,grid_frequency,turbine_state\n"
+        "2026-02-09 12:00:00,1800.0,9.5,14.2,270.5,2.1,4.5,65.3,50.02,2\n"
+    ),
+    "siemens_gamesa": (
+        "timestamp,active_power_kw,reactive_power_kvar,wind_speed_nacelle,wind_speed_metmast,rotor_speed,pitch_angle,generator_speed,bearing_temp,availability_status\n"
+        "2026-02-09 12:00:00,2100.0,300.0,8.7,8.5,13.5,3.2,1450.0,58.4,full\n"
+    ),
+    "nordex": (
+        "timestamp,active_power_kw,wind_speed,rotor_speed,blade_angle,generator_temp,transformer_temp,turbine_status\n"
+        "2026-02-09 12:00:00,1500.0,7.8,12.5,5.0,62.0,45.0,running\n"
+    ),
 }
 
 

--- a/transforms/nordex-control.yaml
+++ b/transforms/nordex-control.yaml
@@ -1,0 +1,104 @@
+# Nordex Control SCADA to ODS-E Transform Specification
+# License: CC-BY-SA 4.0
+# Source: Nordex Control SCADA CSV/JSON export
+# SEP: SEP-025
+
+transform:
+  name: nordex-control
+  version: "1.0"
+  oem: Nordex
+  description: Transform Nordex Control SCADA CSV export data to ODS-E format
+  sep: SEP-025
+
+input_schema:
+  format: csv
+  source: Nordex Control SCADA export
+  delimiter: ","
+  header: true
+  columns:
+    - timestamp: datetime              # local or ISO 8601
+    - active_power_kw: float           # kW (>= 0 when producing)
+    - wind_speed: float                # m/s
+    - rotor_speed: float               # RPM (>= 0)
+    - blade_angle: float               # degrees
+    - generator_temp: float            # °C
+    - transformer_temp: float          # °C
+    - turbine_status: string           # running, standby, paused, warning, error, offline, maintenance
+
+output_mapping:
+  from_scada_export:
+    timestamp:
+      source: input.timestamp
+      transform: to_iso8601
+    kWh:
+      function: power_times_interval
+      inputs:
+        - input.active_power_kw
+        - interval_hours
+      description: Energy produced over the interval, floored at 0, in kWh
+    kW:
+      source: input.active_power_kw
+    wind_speed_ms:
+      source: input.wind_speed
+      minimum: 0
+    rotor_rpm:
+      source: input.rotor_speed
+      minimum: 0
+    blade_pitch_deg:
+      source: input.blade_angle
+    temperature:
+      source: input.generator_temp
+    error_type:
+      function: map_turbine_status
+      inputs:
+        - input.turbine_status
+    error_code:
+      source: input.turbine_status
+      transform: to_string
+
+status_mapping:
+  turbine_status_to_error_type:
+    running: normal
+    standby: standby
+    paused: standby
+    warning: warning
+    error: fault
+    offline: offline
+    maintenance: warning
+
+calculations:
+  power_times_interval:
+    description: Energy from power over the interval
+    formula: "max(power_kw * interval_hours, 0.0)"
+
+validation:
+  physical_bounds:
+    wind_speed_ms:
+      min: 0
+      max: 100
+    rotor_rpm:
+      min: 0
+      max: 30
+  temporal:
+    expected_intervals: ["10min", "5min", "1min"]
+    max_gap: "24h"
+    description: Nordex SCADA telemetry typically arrives at 10-minute intervals
+
+conformance:
+  profile: wind_scada
+  required_fields: [wind_speed_ms]
+  description: Use the wind_scada conformance profile to validate wind turbine records
+
+notes: |
+  Nordex is one of the three dominant wind turbine OEMs in the African IPP
+  market. Nordex Control is the SCADA platform used for turbine monitoring
+  and CSV/JSON export of telemetry data.
+
+  The turbine_status string values map to ODS-E error types. "paused" is
+  mapped to "standby" as it represents an intentional temporary stop (e.g.,
+  waiting for wind to pick up), distinct from "standby" which is a manual
+  hold. "maintenance" is mapped to "warning" since the turbine is offline
+  for service but not in a fault condition.
+
+  The wind_scada conformance profile requires wind_speed_ms to be present on
+  every record. See spec/wind-transforms.md (SEP-025).

--- a/transforms/siemens-gamesa-diagnostic.yaml
+++ b/transforms/siemens-gamesa-diagnostic.yaml
@@ -1,0 +1,120 @@
+# Siemens Gamesa Diagnostic System SCADA to ODS-E Transform Specification
+# License: CC-BY-SA 4.0
+# Source: Siemens Gamesa Diagnostic System SCADA CSV/JSON export
+# SEP: SEP-025
+
+transform:
+  name: siemens-gamesa-diagnostic
+  version: "1.0"
+  oem: Siemens Gamesa
+  description: Transform Siemens Gamesa Diagnostic System SCADA CSV export data to ODS-E format
+  sep: SEP-025
+
+input_schema:
+  format: csv
+  source: Siemens Gamesa Diagnostic System SCADA export
+  delimiter: ","
+  header: true
+  columns:
+    - timestamp: datetime              # local or ISO 8601
+    - active_power_kw: float           # kW (>= 0 when producing)
+    - reactive_power_kvar: float       # kVAr
+    - wind_speed_nacelle: float        # m/s (nacelle-mounted anemometer)
+    - wind_speed_metmast: float        # m/s (met mast anemometer, fallback)
+    - rotor_speed: float               # RPM (>= 0)
+    - pitch_angle: float               # degrees
+    - generator_speed: float           # RPM
+    - bearing_temp: float              # °C
+    - availability_status: string      # full, limited, standstill, error, offline, maintenance
+
+output_mapping:
+  from_scada_export:
+    timestamp:
+      source: input.timestamp
+      transform: to_iso8601
+    kWh:
+      function: power_times_interval
+      inputs:
+        - input.active_power_kw
+        - interval_hours
+      description: Energy produced over the interval, floored at 0, in kWh
+    kW:
+      source: input.active_power_kw
+    kVAr:
+      source: input.reactive_power_kvar
+    wind_speed_ms:
+      function: first_available
+      inputs:
+        - input.wind_speed_nacelle
+        - input.wind_speed_metmast
+      minimum: 0
+      description: Prefers nacelle anemometer; falls back to met mast
+    rotor_rpm:
+      source: input.rotor_speed
+      minimum: 0
+    blade_pitch_deg:
+      source: input.pitch_angle
+    temperature:
+      source: input.bearing_temp
+    error_type:
+      function: map_availability_status
+      inputs:
+        - input.availability_status
+    error_code:
+      source: input.availability_status
+      transform: to_string
+
+status_mapping:
+  availability_status_to_error_type:
+    full: normal
+    limited: warning
+    standstill: standby
+    error: fault
+    offline: offline
+    maintenance: warning
+
+calculations:
+  power_times_interval:
+    description: Energy from power over the interval
+    formula: "max(power_kw * interval_hours, 0.0)"
+  first_available:
+    description: Use the first non-null input value
+    formula: "wind_speed_nacelle ?? wind_speed_metmast"
+
+validation:
+  physical_bounds:
+    wind_speed_ms:
+      min: 0
+      max: 100
+    rotor_rpm:
+      min: 0
+      max: 30
+    grid_frequency:
+      min: 45
+      max: 65
+  temporal:
+    expected_intervals: ["10min", "5min", "1min"]
+    max_gap: "24h"
+    description: Siemens Gamesa SCADA telemetry typically arrives at 10-minute intervals
+
+conformance:
+  profile: wind_scada
+  required_fields: [wind_speed_ms]
+  description: Use the wind_scada conformance profile to validate wind turbine records
+
+notes: |
+  Siemens Gamesa (SGRE) is one of the three dominant wind turbine OEMs in the
+  African IPP market. The Siemens Gamesa Diagnostic System is the SCADA platform
+  used for remote monitoring and CSV/JSON export of turbine telemetry.
+
+  The availability_status string values map to ODS-E error types. "limited"
+  indicates the turbine is running at reduced capacity (warning), while
+  "standstill" indicates an intentional stop (standby).
+
+  Wind speed is measured at two locations: the nacelle-mounted anemometer
+  (wind_speed_nacelle) and the met mast (wind_speed_metmast). The transformer
+  prefers the nacelle reading and falls back to the met mast when the nacelle
+  value is absent.
+
+  The wind_scada conformance profile requires wind_speed_ms to be present on
+  every record. See spec/wind-transforms.md (SEP-025).

--- a/transforms/vestas-online.yaml
+++ b/transforms/vestas-online.yaml
@@ -1,0 +1,118 @@
+# Vestas Online SCADA to ODS-E Transform Specification
+# License: CC-BY-SA 4.0
+# Source: Vestas Online SCADA CSV/JSON export
+# SEP: SEP-025
+
+transform:
+  name: vestas-online
+  version: "1.0"
+  oem: Vestas
+  description: Transform Vestas Online SCADA CSV export data to ODS-E format
+  sep: SEP-025
+
+input_schema:
+  format: csv
+  source: Vestas Online Business SCADA export
+  delimiter: ","
+  header: true
+  columns:
+    - timestamp: datetime              # local or ISO 8601
+    - active_power_kw: float           # kW (>= 0 when producing)
+    - wind_speed: float                # m/s
+    - rotor_rpm: float                 # RPM (>= 0)
+    - nacelle_position: float          # degrees (0-360 compass bearing)
+    - yaw_error: float                 # degrees
+    - blade_pitch: float               # degrees
+    - generator_temp: float            # °C
+    - grid_frequency: float            # Hz
+    - turbine_state: integer           # 0=offline, 1=standby, 2=normal, 3=warning, 4=fault, 5=maintenance
+
+output_mapping:
+  from_scada_export:
+    timestamp:
+      source: input.timestamp
+      transform: to_iso8601
+    kWh:
+      function: power_times_interval
+      inputs:
+        - input.active_power_kw
+        - interval_hours
+      description: Energy produced over the interval, floored at 0, in kWh
+    kW:
+      source: input.active_power_kw
+    wind_speed_ms:
+      source: input.wind_speed
+      minimum: 0
+    rotor_rpm:
+      source: input.rotor_rpm
+      minimum: 0
+    nacelle_direction_deg:
+      source: input.nacelle_position
+      bounds: [0, 360]
+    blade_pitch_deg:
+      source: input.blade_pitch
+    temperature:
+      source: input.generator_temp
+    frequency:
+      source: input.grid_frequency
+    error_type:
+      function: map_turbine_state
+      inputs:
+        - input.turbine_state
+    error_code:
+      source: input.turbine_state
+      transform: to_string
+
+status_mapping:
+  turbine_state_to_error_type:
+    0: offline
+    1: standby
+    2: normal
+    3: warning
+    4: fault
+    5: warning  # maintenance
+
+calculations:
+  power_times_interval:
+    description: Energy from power over the interval
+    formula: "max(power_kw * interval_hours, 0.0)"
+
+validation:
+  physical_bounds:
+    wind_speed_ms:
+      min: 0
+      max: 100
+    rotor_rpm:
+      min: 0
+      max: 30
+    nacelle_direction_deg:
+      min: 0
+      max: 360
+    grid_frequency:
+      min: 45
+      max: 65
+  temporal:
+    expected_intervals: ["10min", "5min", "1min"]
+    max_gap: "24h"
+    description: Vestas SCADA telemetry typically arrives at 10-minute intervals
+
+conformance:
+  profile: wind_scada
+  required_fields: [wind_speed_ms]
+  description: Use the wind_scada conformance profile to validate wind turbine records
+
+notes: |
+  Vestas is one of the three dominant wind turbine OEMs in the African IPP
+  market. Vestas Online Business is the SCADA portal used for fleet monitoring
+  and CSV/JSON export of turbine telemetry.
+
+  The turbine_state integer codes map to ODS-E error types as defined above.
+  State 5 (maintenance) is mapped to "warning" since the turbine is intentionally
+  offline for service but not in a fault condition.
+
+  The default interval_minutes is 10, matching the standard Vestas SCADA
+  10-minute reporting interval. Override with interval_minutes for higher
+  resolution data.
+
+  The wind_scada conformance profile requires wind_speed_ms to be present on
+  every record. See spec/wind-transforms.md (SEP-025).


### PR DESCRIPTION
## Summary

- Adds three wind turbine SCADA transformer classes: `VestasTransformer` (Vestas Online), `SiemensGamesaTransformer` (Siemens Gamesa Diagnostic System, with nacelle/met mast wind speed fallback), and `NordexTransformer` (Nordex Control), registered under source keys `vestas`, `siemens_gamesa`, and `nordex`
- Adds four optional wind schema fields to `energy-timeseries.json`: `wind_speed_ms`, `rotor_rpm`, `blade_pitch_deg`, `nacelle_direction_deg` (0–360)
- Adds `wind_scada` conformance profile requiring `wind_speed_ms`
- Adds three YAML transform specs in `transforms/`
- Adds SEP-025 spec document `spec/wind-transforms.md`
- Updates `GOVERNANCE.md` with SEP-025 allocation and `CHANGELOG.md` with Unreleased entries

**Decision class:** Normative (additive optional fields only, no existing fields changed). Requires 2 maintainer approvals + 7-day public comment window per GOVERNANCE.md.

Closes #25

#### Test plan

- [x] 22 new tests in `test_wind_transforms.py` pass (production, standby, fault states for each OEM; dispatcher routing; empty payload; schema validation; profile validation; field bounds)
- [x] Full test suite passes: 209 passed, 30 skipped, 0 failed (30 skips are pre-existing ERP schema tests requiring `jsonschema`)
- [x] Transform harness fixture mode passes for all 14 OEMs (11 existing + 3 new wind)
- [x] No regressions in existing tests