### PR TITLE
Add Terraco SCADA historian transform (SEP-021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is inspired by Keep a Changelog and follows semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- Terraco SCADA historian transform (SEP-021): `TerracoTransformer` handling both JSON (REST API) and CSV (export) inputs, registered under source keys `terraco` and `terraco-historian`. Maps Terraco `{AssetName}.{TagName}` patterns to ODS-E fields with auto-detection of input format.
+
 ## [0.8.0] - 2026-06-27
 
 ### Added

--- a/src/python/odse/transformer.py
+++ b/src/python/odse/transformer.py
@@ -103,6 +103,8 @@ def _get_transformer(source: str):
         "sgre": SiemensGamesaTransformer(),
         "nordex": NordexTransformer(),
         "nordex-control": NordexTransformer(),
+        "terraco": TerracoTransformer(),
+        "terraco-historian": TerracoTransformer(),
         "csv": GenericCSVTransformer(),
         "generic_csv": GenericCSVTransformer(),
         "generic": GenericCSVTransformer(),
@@ -1884,6 +1886,165 @@ class NordexTransformer(BaseTransformer):
             records.append(rec)
 
         return records
+
+
+class TerracoTransformer(BaseTransformer):
+    """Transform Terraco SCADA historian data to ODS-E.
+
+    Handles both JSON (REST API response) and CSV (export) inputs.
+    Terraco uses ``{AssetName}.{TagName}`` naming convention. The transformer
+    matches tag suffixes (case-insensitive) to ODS-E fields.
+
+    JSON structure (REST API):
+        {"data": [{"timestamp": "...", "values": {"JBAY.ActivePower": 1800.0, ...}}]}
+
+    CSV structure (export):
+        timestamp,JBAY.ActivePower,JBAY.ActiveEnergy,JBAY.Status,...
+    """
+
+    # Integer state code -> error_type
+    STATE_MAPPING = {
+        0: "offline",
+        1: "normal",
+        2: "standby",
+        3: "warning",
+        4: "fault",
+        5: "warning",  # maintenance
+    }
+
+    # Tag suffix -> (ODS-E field, is_power_kwh)
+    # Order matters: first match wins per field.
+    TAG_SUFFIX_MAP = [
+        (["activepower", "kw"], "kW", False),
+        (["activeenergy", "kwh"], "kWh", True),
+        (["status", "state"], "error_type", False),
+        (["temperature"], "temperature", False),
+        (["voltage"], "voltage_ac", False),
+        (["current"], "current_ac", False),
+        (["frequency"], "frequency", False),
+        (["reactivepower"], "kVAr", False),
+        (["powerfactor"], "PF", False),
+    ]
+
+    def transform(self, data: Union[str, Path], **kwargs) -> List[Dict[str, Any]]:
+        timezone = kwargs.get("timezone")
+        interval_hours = (kwargs.get("interval_minutes", 10) or 10) / 60.0
+        asset_id = kwargs.get("asset_id")
+
+        # Detect JSON vs CSV input.
+        try:
+            payload = self._parse_json(data)
+            if isinstance(payload, (dict, list)):
+                return self._transform_json(
+                    payload, timezone=timezone, interval_hours=interval_hours,
+                    asset_id=asset_id,
+                )
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+        # Fall back to CSV.
+        rows = self._parse_csv_rows(data)
+        return self._transform_rows(
+            rows, timezone=timezone, interval_hours=interval_hours,
+            asset_id=asset_id,
+        )
+
+    def _transform_json(
+        self, payload: Any, *, timezone: Optional[str],
+        interval_hours: float, asset_id: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        samples = _extract_records(payload)
+        out: List[Dict[str, Any]] = []
+        for sample in samples:
+            ts = _to_iso8601(sample.get("timestamp"), timezone=timezone)
+            if not ts:
+                continue
+            values = sample.get("values")
+            if not isinstance(values, dict):
+                # Flat dict: treat the sample itself as the values map.
+                values = {k: v for k, v in sample.items() if k != "timestamp"}
+            out.append(
+                self._build_record(
+                    ts, values, interval_hours=interval_hours, asset_id=asset_id,
+                )
+            )
+        return out
+
+    def _transform_rows(
+        self, rows: List[Dict[str, Any]], *, timezone: Optional[str],
+        interval_hours: float, asset_id: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        for row in rows:
+            ts_raw = _first_value(row, ["timestamp", "Timestamp", "Time", "datetime"])
+            ts = _to_iso8601(ts_raw, timezone=timezone)
+            if not ts:
+                continue
+            out.append(
+                self._build_record(
+                    ts, row, interval_hours=interval_hours, asset_id=asset_id,
+                )
+            )
+        return out
+
+    def _build_record(
+        self, ts: str, values: Dict[str, Any], *,
+        interval_hours: float, asset_id: Optional[str],
+    ) -> Dict[str, Any]:
+        mapped = self._map_tags(values)
+
+        power_kw = _to_float(mapped.get("kW"))
+        energy_kwh = _to_float(mapped.get("kWh"))
+        if energy_kwh is not None:
+            kwh = max(energy_kwh, 0.0)
+        elif power_kw is not None:
+            kwh = max(power_kw * interval_hours, 0.0)
+        else:
+            kwh = 0.0
+
+        state_code = _to_int(mapped.get("error_type"))
+        error_type = self.STATE_MAPPING.get(
+            state_code if state_code is not None else -1, "unknown",
+        )
+
+        rec = _base_record(
+            timestamp=ts,
+            kwh=kwh,
+            error_type=error_type,
+            error_code=state_code,
+            asset_id=asset_id,
+        )
+
+        if power_kw is not None:
+            rec["kW"] = power_kw
+
+        for field in ["temperature", "voltage_ac", "current_ac", "frequency", "kVAr"]:
+            val = _to_float(mapped.get(field))
+            if val is not None:
+                rec[field] = val
+
+        pf = _to_float(mapped.get("PF"))
+        if pf is not None:
+            rec["PF"] = max(0.0, min(1.0, pf))
+
+        return rec
+
+    def _map_tags(self, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Map Terraco tag names to ODS-E field names via suffix matching."""
+        result: Dict[str, Any] = {}
+        for key, val in values.items():
+            if val is None or val == "":
+                continue
+            key_lower = str(key).lower()
+            # Strip asset prefix: "JBAY.ActivePower" -> "activepower"
+            suffix = key_lower.split(".")[-1] if "." in key_lower else key_lower
+            for suffixes, odse_field, _is_energy in self.TAG_SUFFIX_MAP:
+                if suffix in suffixes:
+                    # Don't overwrite if already mapped (first match wins).
+                    if odse_field not in result:
+                        result[odse_field] = val
+                    break
+        return result
 
 
 class GenericCSVTransformer(BaseTransformer):

--- a/src/python/tests/fixtures/terraco_csv_sample.csv
+++ b/src/python/tests/fixtures/terraco_csv_sample.csv
@@ -1,0 +1,4 @@
+timestamp,JBAY.ActivePower,JBAY.ActiveEnergy,JBAY.Status,JBAY.Temperature,JBAY.Voltage,JBAY.Current,JBAY.Frequency,JBAY.ReactivePower,JBAY.PowerFactor
+2026-06-27T10:00:00+02:00,1800.0,300.0,1,45.2,400.0,12.5,50.0,300.0,0.98
+2026-06-27T10:10:00+02:00,0.0,0.0,2,38.0,400.0,0.0,50.01,0.0,1.0
+2026-06-27T10:20:00+02:00,0.0,0.0,4,35.0,0.0,0.0,0.0,0.0,0.0

--- a/src/python/tests/fixtures/terraco_rest_sample.json
+++ b/src/python/tests/fixtures/terraco_rest_sample.json
@@ -1,0 +1,46 @@
+{
+  "data": [
+    {
+      "timestamp": "2026-06-27T10:00:00+02:00",
+      "values": {
+        "JBAY.ActivePower": 1800.0,
+        "JBAY.ActiveEnergy": 300.0,
+        "JBAY.Status": 1,
+        "JBAY.Temperature": 45.2,
+        "JBAY.Voltage": 400.0,
+        "JBAY.Current": 12.5,
+        "JBAY.Frequency": 50.0,
+        "JBAY.ReactivePower": 300.0,
+        "JBAY.PowerFactor": 0.98
+      }
+    },
+    {
+      "timestamp": "2026-06-27T10:10:00+02:00",
+      "values": {
+        "JBAY.ActivePower": 0.0,
+        "JBAY.ActiveEnergy": 0.0,
+        "JBAY.Status": 2,
+        "JBAY.Temperature": 38.0,
+        "JBAY.Voltage": 400.0,
+        "JBAY.Current": 0.0,
+        "JBAY.Frequency": 50.01,
+        "JBAY.ReactivePower": 0.0,
+        "JBAY.PowerFactor": 1.0
+      }
+    },
+    {
+      "timestamp": "2026-06-27T10:20:00+02:00",
+      "values": {
+        "JBAY.ActivePower": 0.0,
+        "JBAY.ActiveEnergy": 0.0,
+        "JBAY.Status": 4,
+        "JBAY.Temperature": 35.0,
+        "JBAY.Voltage": 0.0,
+        "JBAY.Current": 0.0,
+        "JBAY.Frequency": 0.0,
+        "JBAY.ReactivePower": 0.0,
+        "JBAY.PowerFactor": 0.0
+      }
+    }
+  ]
+}

--- a/src/python/tests/test_terraco_transform.py
+++ b/src/python/tests/test_terraco_transform.py
@@ -1,0 +1,283 @@
+"""Tests for Terraco SCADA historian transformer — SEP-021."""
+
+import json
+import pytest
+from pathlib import Path
+
+from odse.transformer import transform, TerracoTransformer
+from odse.validator import validate
+
+
+@pytest.fixture
+def fixtures_dir():
+    return Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# JSON mode (REST API response)
+# ---------------------------------------------------------------------------
+
+def test_terraco_json_production(fixtures_dir):
+    transformer = TerracoTransformer()
+    records = transformer.transform(
+        fixtures_dir / "terraco_rest_sample.json",
+        interval_minutes=10,
+        asset_id="za-globeleq:wind:jbay-001",
+    )
+
+    assert len(records) == 3
+
+    rec0 = records[0]
+    assert rec0["asset_id"] == "za-globeleq:wind:jbay-001"
+    assert rec0["timestamp"] == "2026-06-27T10:00:00+02:00"
+    assert rec0["error_type"] == "normal"
+    assert rec0["kW"] == 1800.0
+    assert rec0["kWh"] == 300.0
+    assert rec0["temperature"] == 45.2
+    assert rec0["voltage_ac"] == 400.0
+    assert rec0["current_ac"] == 12.5
+    assert rec0["frequency"] == 50.0
+    assert rec0["kVAr"] == 300.0
+    assert rec0["PF"] == 0.98
+
+
+def test_terraco_json_standby(fixtures_dir):
+    transformer = TerracoTransformer()
+    records = transformer.transform(
+        fixtures_dir / "terraco_rest_sample.json",
+        interval_minutes=10,
+    )
+
+    rec1 = records[1]
+    assert rec1["error_type"] == "standby"
+    assert rec1["kWh"] == 0.0
+    assert rec1["kW"] == 0.0
+
+
+def test_terraco_json_fault(fixtures_dir):
+    transformer = TerracoTransformer()
+    records = transformer.transform(
+        fixtures_dir / "terraco_rest_sample.json",
+        interval_minutes=10,
+    )
+
+    rec2 = records[2]
+    assert rec2["error_type"] == "fault"
+    assert rec2["kWh"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# CSV mode (export)
+# ---------------------------------------------------------------------------
+
+def test_terraco_csv_production(fixtures_dir):
+    transformer = TerracoTransformer()
+    records = transformer.transform(
+        fixtures_dir / "terraco_csv_sample.csv",
+        interval_minutes=10,
+        asset_id="za-globeleq:wind:jbay-001",
+    )
+
+    assert len(records) == 3
+
+    rec0 = records[0]
+    assert rec0["asset_id"] == "za-globeleq:wind:jbay-001"
+    assert rec0["timestamp"] == "2026-06-27T10:00:00+02:00"
+    assert rec0["error_type"] == "normal"
+    assert rec0["kW"] == 1800.0
+    assert rec0["kWh"] == 300.0
+    assert rec0["temperature"] == 45.2
+    assert rec0["voltage_ac"] == 400.0
+    assert rec0["current_ac"] == 12.5
+    assert rec0["frequency"] == 50.0
+    assert rec0["kVAr"] == 300.0
+    assert rec0["PF"] == 0.98
+
+
+def test_terraco_csv_standby(fixtures_dir):
+    transformer = TerracoTransformer()
+    records = transformer.transform(
+        fixtures_dir / "terraco_csv_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec1 = records[1]
+    assert rec1["error_type"] == "standby"
+    assert rec1["kWh"] == 0.0
+
+
+def test_terraco_csv_fault(fixtures_dir):
+    transformer = TerracoTransformer()
+    records = transformer.transform(
+        fixtures_dir / "terraco_csv_sample.csv",
+        interval_minutes=10,
+    )
+
+    rec2 = records[2]
+    assert rec2["error_type"] == "fault"
+    assert rec2["kWh"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher routing
+# ---------------------------------------------------------------------------
+
+def test_terraco_via_transform_dispatch_json(fixtures_dir):
+    records = transform(
+        fixtures_dir / "terraco_rest_sample.json",
+        source="terraco",
+        interval_minutes=10,
+    )
+    assert len(records) == 3
+    assert {r["error_type"] for r in records} == {"normal", "standby", "fault"}
+
+
+def test_terraco_via_transform_dispatch_csv(fixtures_dir):
+    records = transform(
+        fixtures_dir / "terraco_csv_sample.csv",
+        source="terraco",
+        interval_minutes=10,
+    )
+    assert len(records) == 3
+
+
+def test_terraco_historian_alias(fixtures_dir):
+    records = transform(
+        fixtures_dir / "terraco_rest_sample.json",
+        source="terraco-historian",
+        interval_minutes=10,
+    )
+    assert len(records) == 3
+
+
+# ---------------------------------------------------------------------------
+# Empty payload handling
+# ---------------------------------------------------------------------------
+
+def test_terraco_empty_json():
+    transformer = TerracoTransformer()
+    records = transformer.transform('{"data": []}')
+    assert records == []
+
+
+def test_terraco_empty_csv():
+    transformer = TerracoTransformer()
+    records = transformer.transform(
+        "timestamp,JBAY.ActivePower,JBAY.Status\n"
+    )
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Tag pattern matching
+# ---------------------------------------------------------------------------
+
+def test_terraco_tag_patterns_different_prefixes():
+    """Various asset prefixes should all map correctly via suffix matching."""
+    transformer = TerracoTransformer()
+    payload = json.dumps({
+        "data": [
+            {
+                "timestamp": "2026-06-27T10:00:00+02:00",
+                "values": {
+                    "SOLARPK.ActivePower": 2500.0,
+                    "SOLARPK.ActiveEnergy": 416.7,
+                    "SOLARPK.Status": 1,
+                },
+            }
+        ]
+    })
+    records = transformer.transform(payload, interval_minutes=10)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["kW"] == 2500.0
+    assert rec["kWh"] == 416.7
+    assert rec["error_type"] == "normal"
+
+
+def test_terraco_tag_patterns_case_insensitive():
+    """Tag suffixes should match case-insensitively."""
+    transformer = TerracoTransformer()
+    payload = json.dumps({
+        "data": [
+            {
+                "timestamp": "2026-06-27T10:00:00+02:00",
+                "values": {
+                    "JBAY.activepower": 1800.0,
+                    "JBAY.ACTIVEENERGY": 300.0,
+                    "JBAY.status": 1,
+                },
+            }
+        ]
+    })
+    records = transformer.transform(payload, interval_minutes=10)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["kW"] == 1800.0
+    assert rec["kWh"] == 300.0
+    assert rec["error_type"] == "normal"
+
+
+def test_terraco_kw_alias_tag():
+    """The 'kW' tag suffix should map to ODS-E kW field."""
+    transformer = TerracoTransformer()
+    payload = json.dumps({
+        "data": [
+            {
+                "timestamp": "2026-06-27T10:00:00+02:00",
+                "values": {
+                    "JBAY.kW": 1800.0,
+                    "JBAY.kWh": 300.0,
+                    "JBAY.State": 1,
+                },
+            }
+        ]
+    })
+    records = transformer.transform(payload, interval_minutes=10)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["kW"] == 1800.0
+    assert rec["kWh"] == 300.0
+    assert rec["error_type"] == "normal"
+
+
+# ---------------------------------------------------------------------------
+# kWh fallback from power × interval
+# ---------------------------------------------------------------------------
+
+def test_terraco_kwh_fallback_from_power():
+    """When ActiveEnergy is absent, kWh should be computed from power × interval."""
+    transformer = TerracoTransformer()
+    payload = json.dumps({
+        "data": [
+            {
+                "timestamp": "2026-06-27T10:00:00+02:00",
+                "values": {
+                    "JBAY.ActivePower": 1800.0,
+                    "JBAY.Status": 1,
+                },
+            }
+        ]
+    })
+    records = transformer.transform(payload, interval_minutes=10)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["kW"] == 1800.0
+    # 1800 kW * (10/60) h = 300 kWh
+    assert rec["kWh"] == pytest.approx(1800.0 * (10.0 / 60.0))
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+def test_terraco_output_schema_valid(fixtures_dir):
+    for fixture_name in ["terraco_rest_sample.json", "terraco_csv_sample.csv"]:
+        records = transform(
+            fixtures_dir / fixture_name,
+            source="terraco",
+            interval_minutes=10,
+        )
+        for rec in records:
+            result = validate(rec)
+            assert not result.errors, f"{fixture_name}: Schema errors: {result.errors}"

--- a/tools/transform_harness.py
+++ b/tools/transform_harness.py
@@ -34,6 +34,7 @@ CANONICAL_OEMS = [
     "vestas",
     "siemens_gamesa",
     "nordex",
+    "terraco",
 ]
 
 FIXTURES: Dict[str, str] = {
@@ -140,6 +141,24 @@ FIXTURES: Dict[str, str] = {
         "timestamp,active_power_kw,wind_speed,rotor_speed,blade_angle,generator_temp,transformer_temp,turbine_status\n"
         "2026-02-09 12:00:00,1500.0,7.8,12.5,5.0,62.0,45.0,running\n"
     ),
+    "terraco": json.dumps({
+        "data": [
+            {
+                "timestamp": "2026-02-09 12:00:00",
+                "values": {
+                    "JBAY.ActivePower": 1800.0,
+                    "JBAY.ActiveEnergy": 300.0,
+                    "JBAY.Status": 1,
+                    "JBAY.Temperature": 45.2,
+                    "JBAY.Voltage": 400.0,
+                    "JBAY.Current": 12.5,
+                    "JBAY.Frequency": 50.0,
+                    "JBAY.ReactivePower": 300.0,
+                    "JBAY.PowerFactor": 0.98,
+                },
+            }
+        ]
+    }),
 }
 
 

--- a/transforms/terraco-historian.yaml
+++ b/transforms/terraco-historian.yaml
@@ -1,0 +1,170 @@
+# Terraco SCADA Historian to ODS-E Transform Specification
+# License: CC-BY-SA 4.0
+# Source: Terraco SCADA historian REST API / CSV export
+# SEP: SEP-021
+
+transform:
+  name: terraco-historian
+  version: "1.0"
+  oem: Terraco
+  description: Transform Terraco SCADA historian data (JSON REST API or CSV export) to ODS-E format
+  sep: SEP-021
+
+input_schema:
+  formats:
+    - json
+    - csv
+  source: Terraco SCADA historian REST API or CSV export
+  tag_naming: "{AssetName}.{TagName}"
+  description: |
+    Terraco uses a dot-separated tag naming convention where the prefix is the
+    asset name and the suffix is the measurement name. The transformer matches
+    tag suffixes (case-insensitive) to ODS-E fields.
+
+  json_mode:
+    structure: |
+      {
+        "data": [
+          {
+            "timestamp": "2026-06-27T10:00:00+02:00",
+            "values": {
+              "JBAY.ActivePower": 1800.0,
+              "JBAY.ActiveEnergy": 300.0,
+              "JBAY.Status": 1,
+              ...
+            }
+          }
+        ]
+      }
+    description: |
+      REST API responses contain a "data" array of timestamped samples. Each
+      sample has a "timestamp" field and a "values" dict mapping tag names to
+      values. Bare lists of samples (without "data" wrapper) and single sample
+      dicts are also accepted.
+
+  csv_mode:
+    delimiter: ","
+    header: true
+    columns:
+      - timestamp: datetime
+      - "{AssetName}.ActivePower": float    # kW
+      - "{AssetName}.ActiveEnergy": float   # kWh
+      - "{AssetName}.Status": integer       # state code
+      - "{AssetName}.Temperature": float    # °C
+      - "{AssetName}.Voltage": float        # V
+      - "{AssetName}.Current": float        # A
+      - "{AssetName}.Frequency": float      # Hz
+      - "{AssetName}.ReactivePower": float  # kVAr
+      - "{AssetName}.PowerFactor": float    # 0-1
+
+output_mapping:
+  from_terraco_tags:
+    timestamp:
+      source: input.timestamp
+      transform: to_iso8601
+    kWh:
+      source: input.values[].ActiveEnergy
+      fallback:
+        function: power_times_interval
+        inputs: [input.values[].ActivePower, interval_hours]
+      description: Energy from ActiveEnergy tag, or calculated from power × interval
+    kW:
+      source: input.values[].ActivePower
+    error_type:
+      function: map_state_code
+      inputs:
+        - input.values[].Status
+    error_code:
+      source: input.values[].Status
+      transform: to_string
+    temperature:
+      source: input.values[].Temperature
+    voltage_ac:
+      source: input.values[].Voltage
+    current_ac:
+      source: input.values[].Current
+    frequency:
+      source: input.values[].Frequency
+    kVAr:
+      source: input.values[].ReactivePower
+    PF:
+      source: input.values[].PowerFactor
+      bounds: [0, 1]
+
+tag_suffix_mapping:
+  description: |
+    Tag suffixes are matched case-insensitively after stripping the asset
+    prefix. First match wins per ODS-E field.
+  mappings:
+    - suffixes: [ActivePower, kW]
+      odse_field: kW
+    - suffixes: [ActiveEnergy, kWh]
+      odse_field: kWh
+    - suffixes: [Status, State]
+      odse_field: error_type
+    - suffixes: [Temperature]
+      odse_field: temperature
+    - suffixes: [Voltage]
+      odse_field: voltage_ac
+    - suffixes: [Current]
+      odse_field: current_ac
+    - suffixes: [Frequency]
+      odse_field: frequency
+    - suffixes: [ReactivePower]
+      odse_field: kVAr
+    - suffixes: [PowerFactor]
+      odse_field: PF
+
+status_mapping:
+  state_code_to_error_type:
+    0: offline
+    1: normal
+    2: standby
+    3: warning
+    4: fault
+    5: warning  # maintenance
+  unknown_code: unknown
+
+calculations:
+  power_times_interval:
+    description: Energy from power over the interval (fallback when ActiveEnergy absent)
+    formula: "max(power_kw * interval_hours, 0.0)"
+
+validation:
+  physical_bounds:
+    PF:
+      min: 0
+      max: 1
+    frequency:
+      min: 45
+      max: 65
+    voltage_ac:
+      min: 0
+      max: 1000
+  temporal:
+    expected_intervals: ["10min", "5min", "1min", "1hour"]
+    max_gap: "24h"
+    description: Terraco SCADA historian data typically arrives at 10-minute intervals
+
+notes: |
+  Terraco is the SCADA historian deployed across multiple South African IPP
+  portfolios including Globeleq. It serves as the primary data source for
+  utility-scale generation monitoring.
+
+  The transformer auto-detects JSON vs CSV input. JSON is attempted first;
+  if parsing fails, CSV is assumed. This allows the same source key to handle
+  both REST API responses and CSV exports without configuration.
+
+  Terraco uses a dot-separated tag naming convention: {AssetName}.{TagName}.
+  The transformer strips the asset prefix and matches the tag suffix
+  case-insensitively. For example, "JBAY.ActivePower" and "SOLARPK.ActivePower"
+  both map to the ODS-E "kW" field.
+
+  The default interval_minutes is 10, matching the standard SCADA historian
+  10-minute reporting interval. When ActiveEnergy/kWh is present, it takes
+  precedence over power-based calculation.
+
+  State codes follow a common SCADA historian convention:
+  0=offline, 1=normal, 2=standby, 3=warning, 4=fault, 5=maintenance.
+  Maintenance (5) is mapped to "warning" since the asset is intentionally
+  offline for service but not in a fault condition.


### PR DESCRIPTION
## Summary

- Adds `TerracoTransformer` handling both JSON (REST API response) and CSV (export) inputs with auto-detection
- Maps Terraco `{AssetName}.{TagName}` patterns to ODS-E fields via case-insensitive suffix matching (ActivePower→kW, ActiveEnergy→kWh, Status→error_type, Temperature→temperature, Voltage→voltage_ac, Current→current_ac, Frequency→frequency, ReactivePower→kVAr, PowerFactor→PF)
- State code mapping: 0=offline, 1=normal, 2=standby, 3=warning, 4=fault, 5=maintenance→warning
- kWh fallback from power × interval when ActiveEnergy tag is absent
- Registered under source keys `terraco` and `terraco-historian`
- Transform spec: `transforms/terraco-historian.yaml`

**Decision class:** Routine (new source type only, no schema changes, existing transforms unchanged).

Closes #21

#### Test plan

- [x] 16 new tests in `test_terraco_transform.py` pass (JSON production/standby/fault, CSV production/standby/fault, dispatcher routing for `terraco` + `terraco-historian` alias, empty JSON/CSV, tag pattern matching with different prefixes, case-insensitive matching, kW/kWh alias tags, kWh fallback from power, schema validation)
- [x] Full test suite passes: 225 passed, 30 skipped, 0 failed
- [x] Transform harness fixture mode passes for all 15 OEMs (14 existing + 1 new Terraco)
- [x] No regressions in existing tests